### PR TITLE
use python 3 for pip/ansible

### DIFF
--- a/adroit/docker/dockerfile-centos.tmpl
+++ b/adroit/docker/dockerfile-centos.tmpl
@@ -1,15 +1,13 @@
 FROM {image}
 
-RUN yum -y update && yum -y install systemd
-# python-pip requires epel, let's avoid that
-RUN curl -sSL https://bootstrap.pypa.io/get-pip.py | python
+RUN yum -y update && yum -y install systemd python3-pip python3-setuptools
+
+# install ansible and additional modules needed
+RUN pip3 install --no-cache-dir ansible netaddr
 
 # prevent systemd from stealing host matchine tty and more
 RUN find /etc/systemd/system/*.wants /lib/systemd/system/*.wants -type l \
 	| grep -v -e dbus -e journal -e tmpfiles | xargs rm -fv
-
-# install ansible and additional modules needed
-RUN pip install --no-cache-dir ansible netaddr
 
 RUN mkdir -p /etc/ansible/roles /etc/ansible/group_vars/all
 RUN printf '{apply_role_playbook}' > /etc/ansible/apply-role.yml

--- a/adroit/docker/dockerfile-debian.tmpl
+++ b/adroit/docker/dockerfile-debian.tmpl
@@ -2,7 +2,7 @@ FROM {image}
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y dist-upgrade && \
-	apt-get install -y --no-install-recommends systemd python-pip python-setuptools && \
+	apt-get install -y --no-install-recommends systemd python3-pip python3-setuptools && \
 	rm -rf /var/lib/apt/lists/* /var/cache/apt /usr/share/doc /usr/share/man
 
 # prevent systemd from stealing host matchine tty and more
@@ -10,7 +10,7 @@ RUN find /etc/systemd/system/*.wants /lib/systemd/system/*.wants -type l \
 	| grep -v -e dbus -e journal -e tmpfiles | xargs rm -fv
 
 # install ansible and additional modules needed
-RUN pip install --no-cache-dir ansible netaddr
+RUN pip3 install --no-cache-dir ansible netaddr
 
 RUN mkdir -p /etc/ansible/roles /etc/ansible/group_vars/all
 RUN printf '{apply_role_playbook}' > /etc/ansible/apply-role.yml

--- a/adroit/tester.py
+++ b/adroit/tester.py
@@ -32,7 +32,7 @@ class TestFailure(Exception):
 
 class AnsibleRoleTester:
     def __init__(self, root_dir, base_name, default_image, extra_vars=None):
-        self.root_dir = str(root_dir)
+        self.root_dir = os.path.abspath(root_dir)
         self.roles_dir = os.path.join(self.root_dir, "roles")
         self.base_name = base_name
         self.default_image = default_image

--- a/adroit/tester.py
+++ b/adroit/tester.py
@@ -32,7 +32,7 @@ class TestFailure(Exception):
 
 class AnsibleRoleTester:
     def __init__(self, root_dir, base_name, default_image, extra_vars=None):
-        self.root_dir = os.path.abspath(root_dir)
+        self.root_dir = os.path.abspath(str(root_dir))
         self.roles_dir = os.path.join(self.root_dir, "roles")
         self.base_name = base_name
         self.default_image = default_image


### PR DESCRIPTION
`docker build` of the ansible container images are failing for weird reasons. just upgrade to python3 to rule out pip weirdness.